### PR TITLE
Added: Command line motif option and way to compute treedepth lower bound

### DIFF
--- a/concuss.py
+++ b/concuss.py
@@ -8,6 +8,7 @@
 
 import argparse
 from lib.run_pipeline import runPipeline
+import sys
 
 
 def main():
@@ -19,10 +20,11 @@ def main():
     parser = argparse.ArgumentParser()
 
     # Add arguments to the argument parser
-    parser.add_argument("graph", help="filename of the large graph", type=str)
-    parser.add_argument("pattern", help="filename of the pattern graph",
-                        type=str)
-    parser.add_argument("config",
+    parser.add_argument("-g", "--graph", help="filename of the large graph",
+                        type=str, required=True)
+    parser.add_argument("-m", "--pattern", help="filename of the pattern graph",
+                        type=str, nargs="+", required=True)
+    parser.add_argument("-cfg","--config",
                         help="filename of the configuration settings",
                         nargs='?', type=str, default='config/default.cfg')
     parser.add_argument("-o", "--output", help="filename of the result",
@@ -37,9 +39,6 @@ def main():
     parser.add_argument("-C", "--coloring-no-verify",
                         help="do not verify correctness of existing coloring",
                         action="store_true")
-    parser.add_argument("-m", "--motif",
-                        help="Specify a motif name and number of vertices to be used",
-                        nargs=2)
 
     # Parse the arguments provided by the user to pass them to the
     # runPipeline method

--- a/concuss.py
+++ b/concuss.py
@@ -37,6 +37,9 @@ def main():
     parser.add_argument("-C", "--coloring-no-verify",
                         help="do not verify correctness of existing coloring",
                         action="store_true")
+    parser.add_argument("-m", "--motif",
+                        help="Specify a motif name and number of vertices to be used",
+                        nargs=2)
 
     # Parse the arguments provided by the user to pass them to the
     # runPipeline method

--- a/lib/graph/pattern_generator.py
+++ b/lib/graph/pattern_generator.py
@@ -26,14 +26,9 @@ def get_generator(pattern_name):
         return path
     elif pattern_name == "star":
         return star
-    elif pattern_name == "biclique":
-        return biclique
     elif pattern_name == "wheel":
         return wheel
-    elif pattern_name == "grid":
-        return grid
-    elif pattern_name == "quasi-clique":
-        return quasi_clique
+
 
 def clique(num_vertices):
     """
@@ -54,6 +49,7 @@ def clique(num_vertices):
     # Return the clique
     return pattern
 
+
 def cycle(num_vertices):
     """
     Creates a cycle of size num_vertices and
@@ -72,6 +68,7 @@ def cycle(num_vertices):
     # Return the cycle
     return pattern
 
+
 def path(num_vertices):
     """
     Creates a path of size num_vertices and
@@ -89,6 +86,7 @@ def path(num_vertices):
         pattern.add_edge(u, u + 1)
     # Return the path
     return pattern
+
 
 def star(num_vertices):
     """
@@ -110,6 +108,7 @@ def star(num_vertices):
     # Return the star
     return pattern
 
+
 def wheel(num_vertices):
     """
     Creates a wheel of size num_vertices and
@@ -129,33 +128,3 @@ def wheel(num_vertices):
 
     # Return the wheel
     return pattern
-
-def biclique(num_vertices):
-    """
-
-    :param num_vertices:
-    :return:
-    """
-
-    # TODO: Implement this
-    pass
-
-def grid(num_vertices):
-    """
-
-    :param num_vertices:
-    :return:
-    """
-
-    # TODO: Implement this
-    pass
-
-def quasi_clique(num_vertices):
-    """
-
-    :param num_vertices:
-    :return:
-    """
-
-    # TODO: Implement this
-    pass

--- a/lib/graph/pattern_generator.py
+++ b/lib/graph/pattern_generator.py
@@ -7,6 +7,7 @@
 #
 
 from lib.graph.graph import Graph
+import sys
 
 def get_generator(pattern_name):
     """
@@ -28,6 +29,10 @@ def get_generator(pattern_name):
         return star
     elif pattern_name == "wheel":
         return wheel
+    else:
+        print "\nPattern name should be one of these:\n" \
+                  "\nclique\ncycle\nwheel\nstar\npath\n"
+        sys.exit(1)
 
 
 def clique(num_vertices):

--- a/lib/graph/pattern_generator.py
+++ b/lib/graph/pattern_generator.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python2.7
+
+#
+# This file is part of CONCUSS, https://github.com/theoryinpractice/concuss/, and is
+# Copyright (C) North Carolina State University, 2015. It is licensed under
+# the three-clause BSD license; see LICENSE.
+#
+
+from lib.graph.graph import Graph
+
+def get_generator(pattern_name):
+    """
+    Return a pattern generator method depending
+    on the kind of pattern that needs to be
+    generated
+
+    :param pattern_name: Name of pattern
+    :return: Callback to method that generates the pattern
+    """
+
+    if pattern_name == "clique":
+        return clique
+    elif pattern_name == "cycle":
+        return cycle
+    elif pattern_name == "path":
+        return path
+    elif pattern_name == "star":
+        return star
+    elif pattern_name == "biclique":
+        return biclique
+    elif pattern_name == "wheel":
+        return wheel
+    elif pattern_name == "grid":
+        return grid
+    elif pattern_name == "quasi-clique":
+        return quasi_clique
+
+def clique(num_vertices):
+    """
+    Creates a clique of size num_vertices and
+    returns a Graph object representing it
+
+    :param num_vertices: The number of vertices in the clique
+    :return: A Graph object representing clique
+
+    """
+
+    # Instantiate a Graph
+    pattern = Graph()
+    # Populate it
+    for u in range(num_vertices):
+        for v in range(u + 1, num_vertices):
+            pattern.add_edge(u, v)
+    # Return the clique
+    return pattern
+
+def cycle(num_vertices):
+    """
+    Creates a cycle of size num_vertices and
+    returns a Graph object representing it
+
+    :param num_vertices: The number of vertices in the cycle
+    :return: A Graph object representing cycle
+
+    """
+
+    # Instantiate a Graph
+    pattern = Graph()
+    # Populate it
+    for u in range(num_vertices):
+        pattern.add_edge(u, (u + 1) % num_vertices)
+    # Return the cycle
+    return pattern
+
+def path(num_vertices):
+    """
+    Creates a path of size num_vertices and
+    returns a Graph object representing it
+
+    :param num_vertices: The number of vertices in the path
+    :return: A Graph object representing path
+
+    """
+
+    # Instantiate a Graph
+    pattern = Graph()
+    # Populate it
+    for u in range(num_vertices - 1):
+        pattern.add_edge(u, u + 1)
+    # Return the path
+    return pattern
+
+def star(num_vertices):
+    """
+    Creates a star of size num_vertices and
+    returns a Graph object representing it
+
+    :param num_vertices: The number of vertices in the star
+    :return: A Graph object representing star
+
+    """
+
+    # Instantiate a Graph
+    pattern = Graph()
+    # Populate it
+    for v in range(num_vertices):
+        if v != 0:
+            pattern.add_edge(0, v)
+
+    # Return the star
+    return pattern
+
+def wheel(num_vertices):
+    """
+    Creates a wheel of size num_vertices and
+    returns a Graph object representing it
+
+    :param num_vertices: The number of vertices in the wheel
+    :return: A Graph object representing wheel
+
+    """
+
+    # Instantiate a cycle
+    pattern = cycle(num_vertices - 1)
+    # Populate it
+    middle_vertex = num_vertices - 1
+    for v in range(num_vertices - 1):
+        pattern.add_edge(v, middle_vertex)
+
+    # Return the wheel
+    return pattern
+
+def biclique(num_vertices):
+    """
+
+    :param num_vertices:
+    :return:
+    """
+
+    # TODO: Implement this
+    pass
+
+def grid(num_vertices):
+    """
+
+    :param num_vertices:
+    :return:
+    """
+
+    # TODO: Implement this
+    pass
+
+def quasi_clique(num_vertices):
+    """
+
+    :param num_vertices:
+    :return:
+    """
+
+    # TODO: Implement this
+    pass

--- a/lib/graph/treedepth.py
+++ b/lib/graph/treedepth.py
@@ -20,7 +20,12 @@ def treedepth(G, pattern_type=None):
 
     if pattern_type:
         # return known treedepth of pattern type
-        return globals()[pattern_type](G)
+        try:
+            return globals()[pattern_type](G)
+        except KeyError:
+            print "\nPattern type should be one of these:\n" \
+                  "\nclique\ncycle\nwheel\nstar\npath\n"
+            sys.exit(1)
     else:
         # return the degeneracy as the lower bound, or 2,
         # whichever is larger
@@ -88,4 +93,4 @@ def cycle(pattern):
 
 if __name__ == "__main__":
     G = load_graph(sys.argv[1])
-    print treedepth(G)
+    print treedepth(G, "nishant")

--- a/lib/graph/treedepth.py
+++ b/lib/graph/treedepth.py
@@ -14,12 +14,111 @@ from lib.graph.graphformats import load_graph
 #        Could potentially use log of the length of
 #        the longest path.  Also could replace function
 #        with command line argument
-def treedepth(G):
+def treedepth(G, pattern_type=None):
     """
     Return a lower bound on the treedepth of graph G
     """
+
+    if pattern_type:
+        return locals()[pattern_type](G)
+    else:
+        return max(2, G.calc_degeneracy())
+
+
+def star(pattern):
+    """
+    Compute the lower bound on treedepth of a star pattern.
+
+    :param pattern: the pattern
+    :return: the treedepth
+    """
+
+    # The treedepth of a star is always 2
     return 2
+
+
+def wheel(pattern):
+    """
+    Compute the lower bound on treedepth of a wheel pattern.
+
+    :param pattern: the pattern
+    :return: the treedepth
+    """
+    # TODO: Implement this
+    pass
+
+
+def path(pattern):
+    """
+    Compute the lower bound on treedepth of a path.
+
+    :param pattern: the pattern
+    :return: the treedepth
+    """
+
+    # Import math library
+    import math
+    # return lower bound
+    return int(math.ceil(math.log(len(pattern) + 1, 2)))
+
+
+def clique(pattern):
+    """
+    Compute the lower bound on treedepth of a clique.
+
+    :param pattern: the pattern
+    :return: the treedepth
+    """
+
+    # The treedepth of a clique is the number of nodes in it
+    return len(pattern)
+
+
+def biclique(pattern):
+    """
+    Compute the lower bound on treedepth of a biclique.
+
+    :param pattern: the pattern
+    :return: the treedepth
+    """
+
+    # The treedepth of a biclique is the number of nodes in it
+    return len(pattern)
+
+
+def cycle(pattern):
+    """
+    Compute the lower bound on treedepth of a cycle.
+
+    :param pattern: the pattern
+    :return: the treedepth
+    """
+
+    # TODO: Implement this
+    pass
+
+def grid(pattern):
+    """
+    Compute the lower bound on treedepth of a grid.
+
+    :param pattern: the pattern
+    :return: the treedepth
+    """
+
+    # TODO: Implement this
+    pass
+
+def quasi_clique(pattern):
+    """
+    Compute the lower bound on treedepth of a quasi_clique.
+
+    :param pattern: the pattern
+    :return: the treedepth
+    """
+
+    # TODO: Implement this
+    pass
 
 if __name__ == "__main__":
     G = load_graph(sys.argv[1])
-    print treeDepth(G)
+    print treedepth(G)

--- a/lib/graph/treedepth.py
+++ b/lib/graph/treedepth.py
@@ -19,8 +19,11 @@ def treedepth(G, pattern_type=None):
     """
 
     if pattern_type:
+        # return known treedepth of pattern type
         return globals()[pattern_type](G)
     else:
+        # return the degeneracy as the lower bound, or 2,
+        # whichever is larger
         return max(2, G.calc_degeneracy())
 
 
@@ -71,19 +74,6 @@ def clique(pattern):
     return len(pattern)
 
 
-def biclique(pattern):
-    """
-    Compute the lower bound on treedepth of a biclique.
-
-    :param pattern: the pattern
-    :return: the treedepth
-    """
-
-    # The treedepth of a biclique is the number of nodes in it
-    # TODO: Implement this
-    pass
-
-
 def cycle(pattern):
     """
     Compute the lower bound on treedepth of a cycle.
@@ -95,28 +85,7 @@ def cycle(pattern):
     # return lower bound
     return int(ceil(log(len(pattern), 2))) + 1
 
-def grid(pattern):
-    """
-    Compute the lower bound on treedepth of a grid.
-
-    :param pattern: the pattern
-    :return: the treedepth
-    """
-
-    # TODO: Implement this
-    pass
-
-def quasi_clique(pattern):
-    """
-    Compute the lower bound on treedepth of a quasi_clique.
-
-    :param pattern: the pattern
-    :return: the treedepth
-    """
-
-    # TODO: Implement this
-    pass
 
 if __name__ == "__main__":
     G = load_graph(sys.argv[1])
-    print treedepth(G, "clique")
+    print treedepth(G)

--- a/lib/graph/treedepth.py
+++ b/lib/graph/treedepth.py
@@ -93,4 +93,4 @@ def cycle(pattern):
 
 if __name__ == "__main__":
     G = load_graph(sys.argv[1])
-    print treedepth(G, "nishant")
+    print treedepth(G)

--- a/lib/graph/treedepth.py
+++ b/lib/graph/treedepth.py
@@ -6,9 +6,8 @@
 
 
 import sys
-from collections import deque
 from lib.graph.graphformats import load_graph
-
+from math import ceil, log
 
 # TODO:  Get a tighter lower bound on the treedepth
 #        Could potentially use log of the length of
@@ -20,7 +19,7 @@ def treedepth(G, pattern_type=None):
     """
 
     if pattern_type:
-        return locals()[pattern_type](G)
+        return globals()[pattern_type](G)
     else:
         return max(2, G.calc_degeneracy())
 
@@ -44,8 +43,8 @@ def wheel(pattern):
     :param pattern: the pattern
     :return: the treedepth
     """
-    # TODO: Implement this
-    pass
+
+    return int(ceil(log(len(pattern) - 1, 2))) + 2
 
 
 def path(pattern):
@@ -56,10 +55,8 @@ def path(pattern):
     :return: the treedepth
     """
 
-    # Import math library
-    import math
     # return lower bound
-    return int(math.ceil(math.log(len(pattern) + 1, 2)))
+    return int(ceil(log(len(pattern) + 1, 2)))
 
 
 def clique(pattern):
@@ -83,7 +80,8 @@ def biclique(pattern):
     """
 
     # The treedepth of a biclique is the number of nodes in it
-    return len(pattern)
+    # TODO: Implement this
+    pass
 
 
 def cycle(pattern):
@@ -94,8 +92,8 @@ def cycle(pattern):
     :return: the treedepth
     """
 
-    # TODO: Implement this
-    pass
+    # return lower bound
+    return int(ceil(log(len(pattern), 2))) + 1
 
 def grid(pattern):
     """
@@ -121,4 +119,4 @@ def quasi_clique(pattern):
 
 if __name__ == "__main__":
     G = load_graph(sys.argv[1])
-    print treedepth(G)
+    print treedepth(G, "clique")

--- a/lib/pattern_counting/pattern_counter.py
+++ b/lib/pattern_counting/pattern_counter.py
@@ -22,7 +22,7 @@ class PatternCounter(object):
     the final count from the whole graph.
     """
 
-    def __init__(self, G, H, coloring, pattern_class=KPattern, table_hints={},
+    def __init__(self, G, H, td_lower, coloring, pattern_class=KPattern, table_hints={},
                  decomp_class=CombinationsSweep,
                  combiner_class=InclusionExclusion, verbose=False):
         """
@@ -44,7 +44,7 @@ class PatternCounter(object):
         self.pattern_class = pattern_class
         self.verbose = verbose
 
-        self.combiner = combiner_class(len(H), coloring, table_hints, td=treedepth(H))
+        self.combiner = combiner_class(len(H), coloring, table_hints, td=td_lower)
         # TODO: calculate a lower bound on treedepth
         self.decomp_generator = decomp_class(G, coloring, len(H),
                                              self.combiner.tree_depth,

--- a/lib/run_pipeline.py
+++ b/lib/run_pipeline.py
@@ -51,10 +51,10 @@ def coloring_from_file(filename, graph, td, cfgfile, verbose, verify=False):
         if verbose:
             print "Verifying coloring..."
 
-        Config = parse_config_safe(cfgParser)
-        ldo = import_colmodules(Config.get('modules',
+        Config = parse_config_safe(cfgfile)
+        ldo = import_colmodules(Config.get('color',
                                            'low_degree_orientation'))
-        ctd = import_colmodules(Config.get('modules',
+        ctd = import_colmodules(Config.get('color',
                                            'check_tree_depth'))
         orig, _ = graph.normalize()
 

--- a/lib/run_pipeline.py
+++ b/lib/run_pipeline.py
@@ -92,7 +92,12 @@ def runPipeline(graph, pattern, cfgFile, colorFile, color_no_verify, output,
     if len(pattern) == 2:
         # Get pattern type and number of vertices
         pattern_type = pattern[0]
-        pattern_num_vertices = int(pattern[1])
+        try:
+            pattern_num_vertices = int(pattern[1])
+        except ValueError:
+            print "\nPlease provide an integer as the second argument " \
+                  "to the -m flag\n"
+            sys.exit(1)
         # Get the generator for that type of pattern
         generator = pattern_gen.get_generator(pattern_type)
         # Generate the pattern


### PR DESCRIPTION
## Summary of additions:
### Command line motif option: <code>-m</code> or <code>--pattern</code>

This flag takes either one or two arguments.
In order to supply file name for pattern, use <code>-m pattern.txt </code>
In order to specify pattern description, use <code> -m pattern_name number_of_vertices </code>
The treedepth of the pattern is then computed and passed on to combiners for counting.
### Treedepth lower bound:

_treedepth.py_ now contains a way to compute the lower bound on treedepth of patterns. It currently uses degeneracy as the lower bound. For known lower bounds on treedepth for patterns like cliques, stars, wheels, cycles etc. separate methods have been provided for determining respective lower bounds.
