### PR TITLE
Added: Support for basic patterns and way to compute treedepth lower bound

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Count the number of subgraphs of "graph" which are isomorphic to "pattern".
 Positional arguments:
 
 * `graph` - filename of the host graph
-* `pattern` - filename or basic pattern. Basic pattern specified as: `pattern_nameint`. See example below.
+* `pattern` - filename or basic pattern. Basic pattern specified as: `pattern_nameint` or `pattern_nameint,int`. The ints specify number of vertices. See example below.
 * `config` - filename of the configuration settings (defaults to `config/default.cfg`)
 
 Optional arguments:
@@ -41,6 +41,14 @@ Example output:
 
 This means that there are 270 isomorphisms of K3 (a triangle) in the karate network.  Since the triangle has 3 automorphisms, the karate network has 90 distinct triangles.
 
+Using bipartite basic pattern:
+	
+	./concuss.py testing/graphs/karate.txt biclique2,2
+	
+Example output:
+	
+	Number of occurrences of H in G: 288
+	
 ## Install and Software Requirements
 
 CONCUSS requires a 64-bit operating system and Python 2.7.x interpreter (e.g. CPython or PyPy).  

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ We provide the following commonly used basic patterns:
 
 **1-partite basic patterns:**
 
-<code>clique <br> wheel <br> cycle <br> path <br> star</code>
+<code>clique wheel cycle path star</code>
 
 Usage:
 
@@ -66,11 +66,11 @@ Example output:
 
 **Bi-partite basic patterns:**
 
-<code> biclique</code>
+<code>biclique</code>
 
 Usage:
 
-	.concuss.py {path_to_graph}/graph basicpattern|int,int
+	./concuss.py {path_to_graph}/graph basicpattern|int,int
 	
 `|` represents concatenation. The `ints` specify the number of vertices in the first and second sets of the bi-partite pattern.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Count the number of subgraphs of "graph" which are isomorphic to "pattern".
 Positional arguments:
 
 * `graph` - filename of the host graph
-* `pattern` - filename of the pattern graph
+* `pattern` - filename or basic pattern. Basic pattern specified as: `pattern_nameint`. See example below.
 * `config` - filename of the configuration settings (defaults to `config/default.cfg`)
 
 Optional arguments:
@@ -27,8 +27,14 @@ Optional arguments:
 
 Example command:
 
+Using pattern file:
+	
 	./concuss.py testing/graphs/karate.txt testing/graphs/motifs/K3.txt
 
+Using basic pattern:
+	
+	./concuss.py testing/graphs/karate.txt clique3
+	
 Example output:
 
 	Number of occurrences of H in G: 270

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Count the number of subgraphs of "graph" which are isomorphic to "pattern".
 Positional arguments:
 
 * `graph` - filename of the host graph
-* `pattern` - filename or basic pattern. Basic pattern specified as: `pattern_nameint` or `pattern_nameint,int`. The `int`s specify number of vertices. See example below.
+* `pattern` - filename or basic pattern. See basic patterns section below.
 * `config` - filename of the configuration settings (defaults to `config/default.cfg`)
 
 Optional arguments:
@@ -30,10 +30,6 @@ Example command:
 Using pattern file:
 	
 	./concuss.py testing/graphs/karate.txt testing/graphs/motifs/K3.txt
-
-Using basic pattern:
-	
-	./concuss.py testing/graphs/karate.txt clique3
 	
 Example output:
 
@@ -41,14 +37,51 @@ Example output:
 
 This means that there are 270 isomorphisms of K3 (a triangle) in the karate network.  Since the triangle has 3 automorphisms, the karate network has 90 distinct triangles.
 
-Using bipartite basic pattern:
+
+### Basic patterns:
+
+CONCUSS can be run by providing a basic pattern instead of a pattern file for the `pattern` argument in the execution command. All other positional and optional arguments remain unchanged.
+
+Basic patterns provide a faster and simpler way of specifying patterns to search for in the graph.
+
+We provide the following commonly used basic patterns:
+
+**1-partite basic patterns:**
+
+<code>clique <br> wheel <br> cycle <br> path <br> star</code>
+
+Usage:
+
+	.concuss.py {path_to_graph}/graph basicpattern|int
 	
+`|` represents concatenation. The `int` specifies the number of vertices in pattern.
+
+Example command:
+
+	./concuss.py testing/graphs/karate.txt star4
+	
+Example output:
+
+	Number of occurrences of H in G: 6588
+
+**Bi-partite basic patterns:**
+
+<code> biclique</code>
+
+Usage:
+
+	.concuss.py {path_to_graph}/graph basicpattern|int,int
+	
+`|` represents concatenation. The `ints` specify the number of vertices in the first and second sets of the bi-partite pattern.
+
+Example command:
+
 	./concuss.py testing/graphs/karate.txt biclique2,2
 	
 Example output:
-	
+
 	Number of occurrences of H in G: 288
-	
+
 ## Install and Software Requirements
 
 CONCUSS requires a 64-bit operating system and Python 2.7.x interpreter (e.g. CPython or PyPy).  

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Count the number of subgraphs of "graph" which are isomorphic to "pattern".
 Positional arguments:
 
 * `graph` - filename of the host graph
-* `pattern` - filename or basic pattern. Basic pattern specified as: `pattern_nameint` or `pattern_nameint,int`. The ints specify number of vertices. See example below.
+* `pattern` - filename or basic pattern. Basic pattern specified as: `pattern_nameint` or `pattern_nameint,int`. The `int`s specify number of vertices. See example below.
 * `config` - filename of the configuration settings (defaults to `config/default.cfg`)
 
 Optional arguments:

--- a/concuss.py
+++ b/concuss.py
@@ -8,6 +8,7 @@
 
 import argparse
 from lib.run_pipeline import runPipeline
+import sys
 
 
 def main():
@@ -19,10 +20,11 @@ def main():
     parser = argparse.ArgumentParser()
 
     # Add arguments to the argument parser
-    parser.add_argument("graph", help="filename of the large graph", type=str)
-    parser.add_argument("pattern", help="filename of the pattern graph",
-                        type=str)
-    parser.add_argument("config",
+    parser.add_argument("-g", "--graph", help="filename of the large graph",
+                        type=str, required=True)
+    parser.add_argument("-m", "--pattern", help="filename of the pattern graph",
+                        type=str, nargs="+", required=True)
+    parser.add_argument("-cfg","--config",
                         help="filename of the configuration settings",
                         nargs='?', type=str, default='config/default.cfg')
     parser.add_argument("-o", "--output", help="filename of the result",
@@ -37,9 +39,6 @@ def main():
     parser.add_argument("-C", "--coloring-no-verify",
                         help="do not verify correctness of existing coloring",
                         action="store_true")
-    parser.add_argument("-m", "--motif",
-                        help="Specify a motif name and number of vertices to be used",
-                        nargs=2)
 
     # Parse the arguments provided by the user to pass them to the
     # runPipeline method

--- a/concuss.py
+++ b/concuss.py
@@ -20,11 +20,11 @@ def main():
     parser = argparse.ArgumentParser()
 
     # Add arguments to the argument parser
-    parser.add_argument("-g", "--graph", help="filename of the large graph",
-                        type=str, required=True)
-    parser.add_argument("-m", "--pattern", help="filename of the pattern graph",
-                        type=str, nargs="+", required=True)
-    parser.add_argument("-cfg","--config",
+    parser.add_argument("graph", help="filename of the large graph",
+                        type=str)
+    parser.add_argument("pattern", help="filename of the pattern graph",
+                        type=str)
+    parser.add_argument("config",
                         help="filename of the configuration settings",
                         nargs='?', type=str, default='config/default.cfg')
     parser.add_argument("-o", "--output", help="filename of the result",

--- a/concuss.py
+++ b/concuss.py
@@ -37,6 +37,9 @@ def main():
     parser.add_argument("-C", "--coloring-no-verify",
                         help="do not verify correctness of existing coloring",
                         action="store_true")
+    parser.add_argument("-m", "--motif",
+                        help="Specify a motif name and number of vertices to be used",
+                        nargs=2)
 
     # Parse the arguments provided by the user to pass them to the
     # runPipeline method

--- a/lib/graph/pattern_generator.py
+++ b/lib/graph/pattern_generator.py
@@ -26,14 +26,9 @@ def get_generator(pattern_name):
         return path
     elif pattern_name == "star":
         return star
-    elif pattern_name == "biclique":
-        return biclique
     elif pattern_name == "wheel":
         return wheel
-    elif pattern_name == "grid":
-        return grid
-    elif pattern_name == "quasi-clique":
-        return quasi_clique
+
 
 def clique(num_vertices):
     """
@@ -54,6 +49,7 @@ def clique(num_vertices):
     # Return the clique
     return pattern
 
+
 def cycle(num_vertices):
     """
     Creates a cycle of size num_vertices and
@@ -72,6 +68,7 @@ def cycle(num_vertices):
     # Return the cycle
     return pattern
 
+
 def path(num_vertices):
     """
     Creates a path of size num_vertices and
@@ -89,6 +86,7 @@ def path(num_vertices):
         pattern.add_edge(u, u + 1)
     # Return the path
     return pattern
+
 
 def star(num_vertices):
     """
@@ -110,6 +108,7 @@ def star(num_vertices):
     # Return the star
     return pattern
 
+
 def wheel(num_vertices):
     """
     Creates a wheel of size num_vertices and
@@ -129,33 +128,3 @@ def wheel(num_vertices):
 
     # Return the wheel
     return pattern
-
-def biclique(num_vertices):
-    """
-
-    :param num_vertices:
-    :return:
-    """
-
-    # TODO: Implement this
-    pass
-
-def grid(num_vertices):
-    """
-
-    :param num_vertices:
-    :return:
-    """
-
-    # TODO: Implement this
-    pass
-
-def quasi_clique(num_vertices):
-    """
-
-    :param num_vertices:
-    :return:
-    """
-
-    # TODO: Implement this
-    pass

--- a/lib/graph/pattern_generator.py
+++ b/lib/graph/pattern_generator.py
@@ -7,6 +7,7 @@
 #
 
 from lib.graph.graph import Graph
+import sys
 
 def get_generator(pattern_name):
     """
@@ -28,6 +29,10 @@ def get_generator(pattern_name):
         return star
     elif pattern_name == "wheel":
         return wheel
+    else:
+        print "\nPattern name should be one of these:\n" \
+                  "\nclique\ncycle\nwheel\nstar\npath\n"
+        sys.exit(1)
 
 
 def clique(num_vertices):

--- a/lib/graph/pattern_generator.py
+++ b/lib/graph/pattern_generator.py
@@ -32,6 +32,7 @@ def get_generator(pattern_name):
 
     :param pattern_name: Name of pattern
     :return: Callback to method that generates the pattern
+    :throws: KeyError if pattern_name is not supported
     """
     return getattr(sys.modules[__name__], supported_patterns[pattern_name])
 

--- a/lib/graph/pattern_generator.py
+++ b/lib/graph/pattern_generator.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python2.7
+
+#
+# This file is part of CONCUSS, https://github.com/theoryinpractice/concuss/, and is
+# Copyright (C) North Carolina State University, 2015. It is licensed under
+# the three-clause BSD license; see LICENSE.
+#
+
+from lib.graph.graph import Graph
+
+def get_generator(pattern_name):
+    """
+    Return a pattern generator method depending
+    on the kind of pattern that needs to be
+    generated
+
+    :param pattern_name: Name of pattern
+    :return: Callback to method that generates the pattern
+    """
+
+    if pattern_name == "clique":
+        return clique
+    elif pattern_name == "cycle":
+        return cycle
+    elif pattern_name == "path":
+        return path
+    elif pattern_name == "star":
+        return star
+    elif pattern_name == "biclique":
+        return biclique
+    elif pattern_name == "wheel":
+        return wheel
+    elif pattern_name == "grid":
+        return grid
+    elif pattern_name == "quasi-clique":
+        return quasi_clique
+
+def clique(num_vertices):
+    """
+    Creates a clique of size num_vertices and
+    returns a Graph object representing it
+
+    :param num_vertices: The number of vertices in the clique
+    :return: A Graph object representing clique
+
+    """
+
+    # Instantiate a Graph
+    pattern = Graph()
+    # Populate it
+    for u in range(num_vertices):
+        for v in range(u + 1, num_vertices):
+            pattern.add_edge(u, v)
+    # Return the clique
+    return pattern
+
+def cycle(num_vertices):
+    """
+    Creates a cycle of size num_vertices and
+    returns a Graph object representing it
+
+    :param num_vertices: The number of vertices in the cycle
+    :return: A Graph object representing cycle
+
+    """
+
+    # Instantiate a Graph
+    pattern = Graph()
+    # Populate it
+    for u in range(num_vertices):
+        pattern.add_edge(u, (u + 1) % num_vertices)
+    # Return the cycle
+    return pattern
+
+def path(num_vertices):
+    """
+    Creates a path of size num_vertices and
+    returns a Graph object representing it
+
+    :param num_vertices: The number of vertices in the path
+    :return: A Graph object representing path
+
+    """
+
+    # Instantiate a Graph
+    pattern = Graph()
+    # Populate it
+    for u in range(num_vertices - 1):
+        pattern.add_edge(u, u + 1)
+    # Return the path
+    return pattern
+
+def star(num_vertices):
+    """
+    Creates a star of size num_vertices and
+    returns a Graph object representing it
+
+    :param num_vertices: The number of vertices in the star
+    :return: A Graph object representing star
+
+    """
+
+    # Instantiate a Graph
+    pattern = Graph()
+    # Populate it
+    for v in range(num_vertices):
+        if v != 0:
+            pattern.add_edge(0, v)
+
+    # Return the star
+    return pattern
+
+def wheel(num_vertices):
+    """
+    Creates a wheel of size num_vertices and
+    returns a Graph object representing it
+
+    :param num_vertices: The number of vertices in the wheel
+    :return: A Graph object representing wheel
+
+    """
+
+    # Instantiate a cycle
+    pattern = cycle(num_vertices - 1)
+    # Populate it
+    middle_vertex = num_vertices - 1
+    for v in range(num_vertices - 1):
+        pattern.add_edge(v, middle_vertex)
+
+    # Return the wheel
+    return pattern
+
+def biclique(num_vertices):
+    """
+
+    :param num_vertices:
+    :return:
+    """
+
+    # TODO: Implement this
+    pass
+
+def grid(num_vertices):
+    """
+
+    :param num_vertices:
+    :return:
+    """
+
+    # TODO: Implement this
+    pass
+
+def quasi_clique(num_vertices):
+    """
+
+    :param num_vertices:
+    :return:
+    """
+
+    # TODO: Implement this
+    pass

--- a/lib/graph/pattern_generator.py
+++ b/lib/graph/pattern_generator.py
@@ -6,7 +6,7 @@
 # the three-clause BSD license; see LICENSE.
 #
 
-from graph import Graph
+from lib.graph.graph import Graph
 import sys
 
 

--- a/lib/graph/pattern_generator.py
+++ b/lib/graph/pattern_generator.py
@@ -6,8 +6,23 @@
 # the three-clause BSD license; see LICENSE.
 #
 
-from lib.graph.graph import Graph
+from graph import Graph
 import sys
+
+
+# Global dictionary of supported patterns
+# Represented as -
+# key: pattern name
+# value: method name for generating pattern
+supported_patterns = {"clique": "clique",
+                      "path": "path",
+                      "star": "star",
+                      "wheel": "wheel",
+                      "cycle": "cycle",
+                      "biclique": "biclique"}
+
+bipartite_patterns = ["biclique"]
+
 
 def get_generator(pattern_name):
     """
@@ -18,21 +33,7 @@ def get_generator(pattern_name):
     :param pattern_name: Name of pattern
     :return: Callback to method that generates the pattern
     """
-
-    if pattern_name == "clique":
-        return clique
-    elif pattern_name == "cycle":
-        return cycle
-    elif pattern_name == "path":
-        return path
-    elif pattern_name == "star":
-        return star
-    elif pattern_name == "wheel":
-        return wheel
-    else:
-        print "\nPattern name should be one of these:\n" \
-                  "\nclique\ncycle\nwheel\nstar\npath\n"
-        sys.exit(1)
+    return getattr(sys.modules[__name__], supported_patterns[pattern_name])
 
 
 def clique(num_vertices):
@@ -132,4 +133,24 @@ def wheel(num_vertices):
         pattern.add_edge(v, middle_vertex)
 
     # Return the wheel
+    return pattern
+
+def biclique(m, n):
+    """
+    Creates a biclique of size m + n and
+    returns a Graph object representing it
+
+    :param m: The number of vertices in the first set
+    :param n: The number of vertices in the second set
+    :return: A Graph object representing the biclique
+
+    """
+
+    # Instantiate a Graph
+    pattern = Graph()
+    for u in range(m):
+        for v in range(m, m + n):
+            pattern.add_edge(u, v)
+
+    # Return the biclique
     return pattern

--- a/lib/graph/treedepth.py
+++ b/lib/graph/treedepth.py
@@ -16,19 +16,26 @@ from lib.graph.pattern_generator import supported_patterns
 #        with command line argument
 
 
-def treedepth(G, pattern_info=None):
+def treedepth(G, *pattern_info):
     """
     Return a lower bound on the treedepth of graph G
     """
 
-    if pattern_info:
-        # return known treedepth of pattern type
+    if len(pattern_info):
+        # return known treedepth
         try:
+            # Extract the necessary pieces from pattern_info
             pattern_name = pattern_info[0]
-            num_vertices = pattern_info[1]
-            return globals()[pattern_name](num_vertices)
-        except KeyError:
+            num_elem_tuple = pattern_info[1:]
+
+            # Used for internal error checking
+            if len(num_elem_tuple) == 0:
+                raise IndexError
+
+            return globals()[pattern_name](num_elem_tuple)
+        except (KeyError, IndexError):
             print "\nPattern '" + pattern_info[0] + "' is not supported."
+            print "\n\nor\n\nNumber of vertices in pattern have not been passed."
             print "\nSupported patterns:\n"
             print "\n".join(supported_patterns.iterkeys())
             print
@@ -43,7 +50,7 @@ def star(num_vertices):
     """
     Compute the lower bound on treedepth of a star pattern.
 
-    :param pattern: the pattern
+    :param num_vertices: Tuple containing number of elements
     :return: the treedepth
     """
 
@@ -55,59 +62,61 @@ def wheel(num_vertices):
     """
     Compute the lower bound on treedepth of a wheel pattern.
 
-    :param pattern: the pattern
+    :param num_vertices: Tuple containing number of elements
     :return: the treedepth
     """
 
-    return int(ceil(log(num_vertices - 1, 2))) + 2
+    return int(ceil(log(num_vertices[0] - 1, 2))) + 2
 
 
 def path(num_vertices):
     """
     Compute the lower bound on treedepth of a path.
 
-    :param pattern: the pattern
+    :param num_vertices: Tuple containing number of elements
     :return: the treedepth
     """
 
     # return lower bound
-    return int(ceil(log(num_vertices + 1, 2)))
+    return int(ceil(log(num_vertices[0] + 1, 2)))
 
 
 def clique(num_vertices):
     """
     Compute the lower bound on treedepth of a clique.
 
-    :param pattern: the pattern
+    :param num_vertices: Tuple containing number of elements
     :return: the treedepth
     """
 
     # The treedepth of a clique is the number of nodes in it
-    return num_vertices
+    return num_vertices[0]
 
 
 def cycle(num_vertices):
     """
     Compute the lower bound on treedepth of a cycle.
 
-    :param pattern: the pattern
+    :param num_vertices: Tuple containing number of elements
     :return: the treedepth
     """
 
     # return lower bound
-    return int(ceil(log(num_vertices, 2))) + 1
+    return int(ceil(log(num_vertices[0], 2))) + 1
 
-def biclique(m):
+
+def biclique(num_vertices):
     """
     Compute the lower bound on treedepth of a clique.
 
-    :param m: size of smaller set
+    :param num_vertices: 2-Tuple containing number of elements in
+                         first and second set
     :return: the treedepth
     """
 
     # The treedepth of a biclique is the number of nodes in
     # the smaller set + 1
-    return m + 1
+    return min(num_vertices[0], num_vertices[1]) + 1
 
 
 if __name__ == "__main__":

--- a/lib/graph/treedepth.py
+++ b/lib/graph/treedepth.py
@@ -20,7 +20,12 @@ def treedepth(G, pattern_type=None):
 
     if pattern_type:
         # return known treedepth of pattern type
-        return globals()[pattern_type](G)
+        try:
+            return globals()[pattern_type](G)
+        except KeyError:
+            print "\nPattern type should be one of these:\n" \
+                  "\nclique\ncycle\nwheel\nstar\npath\n"
+            sys.exit(1)
     else:
         # return the degeneracy as the lower bound, or 2,
         # whichever is larger
@@ -88,4 +93,4 @@ def cycle(pattern):
 
 if __name__ == "__main__":
     G = load_graph(sys.argv[1])
-    print treedepth(G)
+    print treedepth(G, "nishant")

--- a/lib/graph/treedepth.py
+++ b/lib/graph/treedepth.py
@@ -14,12 +14,111 @@ from lib.graph.graphformats import load_graph
 #        Could potentially use log of the length of
 #        the longest path.  Also could replace function
 #        with command line argument
-def treedepth(G):
+def treedepth(G, pattern_type=None):
     """
     Return a lower bound on the treedepth of graph G
     """
+
+    if pattern_type:
+        return locals()[pattern_type](G)
+    else:
+        return max(2, G.calc_degeneracy())
+
+
+def star(pattern):
+    """
+    Compute the lower bound on treedepth of a star pattern.
+
+    :param pattern: the pattern
+    :return: the treedepth
+    """
+
+    # The treedepth of a star is always 2
     return 2
+
+
+def wheel(pattern):
+    """
+    Compute the lower bound on treedepth of a wheel pattern.
+
+    :param pattern: the pattern
+    :return: the treedepth
+    """
+    # TODO: Implement this
+    pass
+
+
+def path(pattern):
+    """
+    Compute the lower bound on treedepth of a path.
+
+    :param pattern: the pattern
+    :return: the treedepth
+    """
+
+    # Import math library
+    import math
+    # return lower bound
+    return int(math.ceil(math.log(len(pattern) + 1, 2)))
+
+
+def clique(pattern):
+    """
+    Compute the lower bound on treedepth of a clique.
+
+    :param pattern: the pattern
+    :return: the treedepth
+    """
+
+    # The treedepth of a clique is the number of nodes in it
+    return len(pattern)
+
+
+def biclique(pattern):
+    """
+    Compute the lower bound on treedepth of a biclique.
+
+    :param pattern: the pattern
+    :return: the treedepth
+    """
+
+    # The treedepth of a biclique is the number of nodes in it
+    return len(pattern)
+
+
+def cycle(pattern):
+    """
+    Compute the lower bound on treedepth of a cycle.
+
+    :param pattern: the pattern
+    :return: the treedepth
+    """
+
+    # TODO: Implement this
+    pass
+
+def grid(pattern):
+    """
+    Compute the lower bound on treedepth of a grid.
+
+    :param pattern: the pattern
+    :return: the treedepth
+    """
+
+    # TODO: Implement this
+    pass
+
+def quasi_clique(pattern):
+    """
+    Compute the lower bound on treedepth of a quasi_clique.
+
+    :param pattern: the pattern
+    :return: the treedepth
+    """
+
+    # TODO: Implement this
+    pass
 
 if __name__ == "__main__":
     G = load_graph(sys.argv[1])
-    print treeDepth(G)
+    print treedepth(G)

--- a/lib/graph/treedepth.py
+++ b/lib/graph/treedepth.py
@@ -8,23 +8,30 @@
 import sys
 from lib.graph.graphformats import load_graph
 from math import ceil, log
+from lib.graph.pattern_generator import supported_patterns
 
 # TODO:  Get a tighter lower bound on the treedepth
 #        Could potentially use log of the length of
 #        the longest path.  Also could replace function
 #        with command line argument
-def treedepth(G, pattern_type=None):
+
+
+def treedepth(G, pattern_info=None):
     """
     Return a lower bound on the treedepth of graph G
     """
 
-    if pattern_type:
+    if pattern_info:
         # return known treedepth of pattern type
         try:
-            return globals()[pattern_type](G)
+            pattern_name = pattern_info[0]
+            num_vertices = pattern_info[1]
+            return globals()[pattern_name](num_vertices)
         except KeyError:
-            print "\nPattern type should be one of these:\n" \
-                  "\nclique\ncycle\nwheel\nstar\npath\n"
+            print "\nPattern '" + pattern_info[0] + "' is not supported."
+            print "\nSupported patterns:\n"
+            print "\n".join(supported_patterns.iterkeys())
+            print
             sys.exit(1)
     else:
         # return the degeneracy as the lower bound, or 2,
@@ -32,7 +39,7 @@ def treedepth(G, pattern_type=None):
         return max(2, G.calc_degeneracy())
 
 
-def star(pattern):
+def star(num_vertices):
     """
     Compute the lower bound on treedepth of a star pattern.
 
@@ -44,7 +51,7 @@ def star(pattern):
     return 2
 
 
-def wheel(pattern):
+def wheel(num_vertices):
     """
     Compute the lower bound on treedepth of a wheel pattern.
 
@@ -52,10 +59,10 @@ def wheel(pattern):
     :return: the treedepth
     """
 
-    return int(ceil(log(len(pattern) - 1, 2))) + 2
+    return int(ceil(log(num_vertices - 1, 2))) + 2
 
 
-def path(pattern):
+def path(num_vertices):
     """
     Compute the lower bound on treedepth of a path.
 
@@ -64,10 +71,10 @@ def path(pattern):
     """
 
     # return lower bound
-    return int(ceil(log(len(pattern) + 1, 2)))
+    return int(ceil(log(num_vertices + 1, 2)))
 
 
-def clique(pattern):
+def clique(num_vertices):
     """
     Compute the lower bound on treedepth of a clique.
 
@@ -76,10 +83,10 @@ def clique(pattern):
     """
 
     # The treedepth of a clique is the number of nodes in it
-    return len(pattern)
+    return num_vertices
 
 
-def cycle(pattern):
+def cycle(num_vertices):
     """
     Compute the lower bound on treedepth of a cycle.
 
@@ -88,7 +95,19 @@ def cycle(pattern):
     """
 
     # return lower bound
-    return int(ceil(log(len(pattern), 2))) + 1
+    return int(ceil(log(num_vertices, 2))) + 1
+
+def biclique(m):
+    """
+    Compute the lower bound on treedepth of a clique.
+
+    :param m: size of smaller set
+    :return: the treedepth
+    """
+
+    # The treedepth of a biclique is the number of nodes in
+    # the smaller set + 1
+    return m + 1
 
 
 if __name__ == "__main__":

--- a/lib/graph/treedepth.py
+++ b/lib/graph/treedepth.py
@@ -19,8 +19,11 @@ def treedepth(G, pattern_type=None):
     """
 
     if pattern_type:
+        # return known treedepth of pattern type
         return globals()[pattern_type](G)
     else:
+        # return the degeneracy as the lower bound, or 2,
+        # whichever is larger
         return max(2, G.calc_degeneracy())
 
 
@@ -71,19 +74,6 @@ def clique(pattern):
     return len(pattern)
 
 
-def biclique(pattern):
-    """
-    Compute the lower bound on treedepth of a biclique.
-
-    :param pattern: the pattern
-    :return: the treedepth
-    """
-
-    # The treedepth of a biclique is the number of nodes in it
-    # TODO: Implement this
-    pass
-
-
 def cycle(pattern):
     """
     Compute the lower bound on treedepth of a cycle.
@@ -95,28 +85,7 @@ def cycle(pattern):
     # return lower bound
     return int(ceil(log(len(pattern), 2))) + 1
 
-def grid(pattern):
-    """
-    Compute the lower bound on treedepth of a grid.
-
-    :param pattern: the pattern
-    :return: the treedepth
-    """
-
-    # TODO: Implement this
-    pass
-
-def quasi_clique(pattern):
-    """
-    Compute the lower bound on treedepth of a quasi_clique.
-
-    :param pattern: the pattern
-    :return: the treedepth
-    """
-
-    # TODO: Implement this
-    pass
 
 if __name__ == "__main__":
     G = load_graph(sys.argv[1])
-    print treedepth(G, "clique")
+    print treedepth(G)

--- a/lib/graph/treedepth.py
+++ b/lib/graph/treedepth.py
@@ -93,4 +93,4 @@ def cycle(pattern):
 
 if __name__ == "__main__":
     G = load_graph(sys.argv[1])
-    print treedepth(G, "nishant")
+    print treedepth(G)

--- a/lib/graph/treedepth.py
+++ b/lib/graph/treedepth.py
@@ -6,9 +6,8 @@
 
 
 import sys
-from collections import deque
 from lib.graph.graphformats import load_graph
-
+from math import ceil, log
 
 # TODO:  Get a tighter lower bound on the treedepth
 #        Could potentially use log of the length of
@@ -20,7 +19,7 @@ def treedepth(G, pattern_type=None):
     """
 
     if pattern_type:
-        return locals()[pattern_type](G)
+        return globals()[pattern_type](G)
     else:
         return max(2, G.calc_degeneracy())
 
@@ -44,8 +43,8 @@ def wheel(pattern):
     :param pattern: the pattern
     :return: the treedepth
     """
-    # TODO: Implement this
-    pass
+
+    return int(ceil(log(len(pattern) - 1, 2))) + 2
 
 
 def path(pattern):
@@ -56,10 +55,8 @@ def path(pattern):
     :return: the treedepth
     """
 
-    # Import math library
-    import math
     # return lower bound
-    return int(math.ceil(math.log(len(pattern) + 1, 2)))
+    return int(ceil(log(len(pattern) + 1, 2)))
 
 
 def clique(pattern):
@@ -83,7 +80,8 @@ def biclique(pattern):
     """
 
     # The treedepth of a biclique is the number of nodes in it
-    return len(pattern)
+    # TODO: Implement this
+    pass
 
 
 def cycle(pattern):
@@ -94,8 +92,8 @@ def cycle(pattern):
     :return: the treedepth
     """
 
-    # TODO: Implement this
-    pass
+    # return lower bound
+    return int(ceil(log(len(pattern), 2))) + 1
 
 def grid(pattern):
     """
@@ -121,4 +119,4 @@ def quasi_clique(pattern):
 
 if __name__ == "__main__":
     G = load_graph(sys.argv[1])
-    print treedepth(G)
+    print treedepth(G, "clique")

--- a/lib/pattern_counting/pattern_counter.py
+++ b/lib/pattern_counting/pattern_counter.py
@@ -22,7 +22,7 @@ class PatternCounter(object):
     the final count from the whole graph.
     """
 
-    def __init__(self, G, H, coloring, pattern_class=KPattern, table_hints={},
+    def __init__(self, G, H, td_lower, coloring, pattern_class=KPattern, table_hints={},
                  decomp_class=CombinationsSweep,
                  combiner_class=InclusionExclusion, verbose=False):
         """
@@ -44,7 +44,7 @@ class PatternCounter(object):
         self.pattern_class = pattern_class
         self.verbose = verbose
 
-        self.combiner = combiner_class(len(H), coloring, table_hints, td=treedepth(H))
+        self.combiner = combiner_class(len(H), coloring, table_hints, td=td_lower)
         # TODO: calculate a lower bound on treedepth
         self.decomp_generator = decomp_class(G, coloring, len(H),
                                              self.combiner.tree_depth,

--- a/lib/run_pipeline.py
+++ b/lib/run_pipeline.py
@@ -51,10 +51,10 @@ def coloring_from_file(filename, graph, td, cfgfile, verbose, verify=False):
         if verbose:
             print "Verifying coloring..."
 
-        Config = parse_config_safe(cfgParser)
-        ldo = import_colmodules(Config.get('modules',
+        Config = parse_config_safe(cfgfile)
+        ldo = import_colmodules(Config.get('color',
                                            'low_degree_orientation'))
-        ctd = import_colmodules(Config.get('modules',
+        ctd = import_colmodules(Config.get('color',
                                            'check_tree_depth'))
         orig, _ = graph.normalize()
 

--- a/lib/run_pipeline.py
+++ b/lib/run_pipeline.py
@@ -92,7 +92,12 @@ def runPipeline(graph, pattern, cfgFile, colorFile, color_no_verify, output,
     if len(pattern) == 2:
         # Get pattern type and number of vertices
         pattern_type = pattern[0]
-        pattern_num_vertices = int(pattern[1])
+        try:
+            pattern_num_vertices = int(pattern[1])
+        except ValueError:
+            print "\nPlease provide an integer as the second argument " \
+                  "to the -m flag\n"
+            sys.exit(1)
         # Get the generator for that type of pattern
         generator = pattern_gen.get_generator(pattern_type)
         # Generate the pattern

--- a/lib/run_pipeline.py
+++ b/lib/run_pipeline.py
@@ -80,6 +80,88 @@ def p_centered_coloring(graph, td, cfgfile, verbose):
     return col
 
 
+def pattern_argument_error_msg():
+    print "\nThe argument provided for 'pattern' is invalid.\n"
+    print "Please use format:\n\n" \
+          "\033[1mfilename.txt \033[0m\n" \
+          "For example: ./path_to_file/K3.txt" \
+          "\n\nor\n\n" \
+          "Basic patterns:\n\n" \
+          "Usage: \033[1mpattern_nameint\033[0m\n" \
+          "For example: clique3\n" \
+          "\nor for bipartite patterns:\n" \
+          "Usage: \033[1mpattern_nameint,int\033[0m\n" \
+          "For example: biclique3,4\n" \
+          "\nSupported basic patterns:\n"
+    print "\n".join(pattern_gen.supported_patterns)
+    print
+    sys.exit(1)
+
+def parse_pattern_argument(pattern):
+    """
+    Parses the 'pattern' command line argument.
+    Checks to see if this argument is a filename or
+    a description of the pattern
+
+    :param pattern: Filename or description of pattern
+    :return: A tuple with the pattern graph and a lower
+             bound on its treedepth
+    """
+    import os
+
+    # Get the name of the file and the file extension
+    name, ext = os.path.splitext(pattern)
+    # There is no extension, so argument is a description
+    # of the pattern
+    if ext == "":
+        import re
+        p = re.compile(r'(\d*)')
+        # Parse out the different parts of the argument
+        args = filter(lambda x: x != "" and x != ",", p.split(pattern))
+        # There are two parts
+        if len(args) == 2 and args[0] not in pattern_gen.bipartite_patterns:
+            try:
+                # Get the generator for the pattern type
+                generator = pattern_gen.get_generator(args[0])
+                # Get the number of vertices provided
+                pattern_num_vertices = int(args[1])
+                # Generate the pattern
+                H = generator(pattern_num_vertices)
+                # Return the pattern along with its treedepth
+                return H, treedepth(H, [args[0], pattern_num_vertices])
+            except KeyError:
+                pattern_argument_error_msg()
+
+        # Bipartite pattern type provided
+        elif len(args) == 3 and args[0] in pattern_gen.bipartite_patterns:
+            # Make sure it is a valid bipartite pattern
+            try:
+                generator = pattern_gen.get_generator(args[0])
+                # Try to get the two set sizes
+                m = int(args[1])
+                n = int(args[2])
+                # Generate the pattern
+                H = generator(m, n)
+                # Return the pattern along with its treedepth
+                return H, treedepth(H, [args[0], min(m,n)])
+            except (KeyError, ValueError):
+                # Invalid sizes provided
+                pattern_argument_error_msg()
+        else:
+            # Number of vertices not provided in argument
+            pattern_argument_error_msg()
+    else:
+        # Argument is a filename
+        try:
+            # Try to load the graph from file
+            H = load_graph(pattern)
+            # Return pattern along with lower bound on its treedepth
+            return H, treedepth(H)
+        except Exception:
+            # Invalid file extension
+            pattern_argument_error_msg()
+
+
 def runPipeline(graph, pattern, cfgFile, colorFile, color_no_verify, output,
                 verbose, profile):
     """Basic running of the pipeline"""
@@ -88,27 +170,7 @@ def runPipeline(graph, pattern, cfgFile, colorFile, color_no_verify, output,
         readProfile = cProfile.Profile()
         readProfile.enable()
 
-    # If the user specifies the pattern name for ex. as -> clique 4
-    if len(pattern) == 2:
-        # Get pattern type and number of vertices
-        pattern_type = pattern[0]
-        try:
-            pattern_num_vertices = int(pattern[1])
-        except ValueError:
-            print "\nPlease provide an integer as the second argument " \
-                  "to the -m flag\n"
-            sys.exit(1)
-        # Get the generator for that type of pattern
-        generator = pattern_gen.get_generator(pattern_type)
-        # Generate the pattern
-        H = generator(pattern_num_vertices)
-        # Compute lower bound given the pattern
-        td_lower = treedepth(H, pattern_type)
-    else:
-        # Load pattern from file
-        H = load_graph(pattern[0])
-        # Computer lower bound
-        td_lower = treedepth(H)
+    H, td_lower = parse_pattern_argument(pattern)
 
     # Read graphs from file
     G = load_graph(graph)

--- a/lib/run_pipeline.py
+++ b/lib/run_pipeline.py
@@ -128,7 +128,7 @@ def parse_pattern_argument(pattern):
                 # Generate the pattern
                 H = generator(pattern_num_vertices)
                 # Return the pattern along with its treedepth
-                return H, treedepth(H, [args[0], pattern_num_vertices])
+                return H, treedepth(H, args[0], pattern_num_vertices)
             except KeyError:
                 pattern_argument_error_msg()
 
@@ -143,7 +143,7 @@ def parse_pattern_argument(pattern):
                 # Generate the pattern
                 H = generator(m, n)
                 # Return the pattern along with its treedepth
-                return H, treedepth(H, [args[0], min(m,n)])
+                return H, treedepth(H, args[0], m, n)
             except (KeyError, ValueError):
                 # Invalid sizes provided
                 pattern_argument_error_msg()

--- a/testing/graph_size.py
+++ b/testing/graph_size.py
@@ -13,11 +13,12 @@ import ConfigParser
 from lib.graph import graph
 from lib.coloring.coloring import *
 from lib.graph.graphformats import load_graph
+from lib.run_pipeline import parse_pattern_argument
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("pattern", help="filename of the pattern graph",
                         type=str)
     args = parser.parse_args()
-    h = load_graph(args.pattern)
+    h, _ = parse_pattern_argument(args.pattern)
     print len(h)

--- a/testing/test_common.sh
+++ b/testing/test_common.sh
@@ -64,6 +64,12 @@ run_nx_test() {
 color_graph() {
 	log_bold "Creating graph coloring..."
 	size=$(${path}/graph_size.py $2)
+
+	re='^[0-9]+$'
+	if ! [[ $size =~ $re ]] ; then
+   		${path}/graph_size.py $2; exit 1
+	fi
+
 	filename=$(basename "$1")
 	coloring_file="${path}/colorings/${filename%.*}${size}"
 	if [ "$#" -lt 3 ]; then


### PR DESCRIPTION
### Summary of additions:

**Support for basic patterns:**
CONCUSS now supports basic patterns. Basic patterns are specified in the `pattern` command line argument. Currently supported basic patterns are `clique`s, `star`s, `wheel`s, `cycle`s, and `biclique`s. More information on using basic patterns is provided in the README.

**Treedepth lower bound:**
_treedepth.py_ now contains a way to compute the lower bound on treedepth of patterns. It currently uses degeneracy as the lower bound. For basic patterns like cliques, stars, wheels, cycles and bicliques, separate methods have been provided for determining respective lower bounds.
