### PR TITLE
changed return type of Graph.neighbours() from frozenset to set

### DIFF
--- a/lib/graph/graph.py
+++ b/lib/graph/graph.py
@@ -326,7 +326,7 @@ class Graph(object):
         :param u: The vertex whose neighbors are to be returned
         :return: A frozenset of containing neighbors of the vertex
         """
-        return frozenset(self.adj[u])
+        return self.adj[u]
 
     def neighbours_set(self, centers):
         """


### PR DESCRIPTION
Instead of constructing a new frozenset each time the function is called, the actual set of neighbors is returned.
