### PR TITLE
Sped up graph.py subgraph function

### DIFF
--- a/lib/graph/graph.py
+++ b/lib/graph/graph.py
@@ -326,7 +326,7 @@ class Graph(object):
         :param u: The vertex whose neighbors are to be returned
         :return: A frozenset of containing neighbors of the vertex
         """
-        return frozenset(self.adj[u])
+        return self.adj[u]
 
     def neighbours_set(self, centers):
         """
@@ -452,7 +452,7 @@ class Graph(object):
 
         for v in selected:
             # It is assumed that all vertices in selected in self.nodes.
-            # Verticies not in self.nodes are added as isolates, as they
+            # Vertices not in self.nodes are added as isolates, as they
             # aren't connected to any other vertices
             res.add_node(v)
 

--- a/lib/graph/graph.py
+++ b/lib/graph/graph.py
@@ -444,18 +444,23 @@ class Graph(object):
         Given a set of vertices, returns the subgraph
         that the vertices induce on the graph
 
-        :param vertices: vertices in the subgraph
+        :param vertices: vertices in the subgraph, assumed to be in self.nodes
         :return: the induced subgraph
         """
         res = Graph()
         selected = set(vertices)
-        for v in self:
-            if v in selected:
-                res.add_node(v)
 
-        for u, v in self.edges():
-            if u in selected and v in selected:
+        for v in selected:
+            # It is assumed that all vertices in selected in self.nodes.
+            # Verticies not in self.nodes are added as isolates, as they
+            # aren't connected to any other vertices
+            res.add_node(v)
+
+        for v in selected:
+            # Isolates will have no neighbors, thus will have no edges
+            for u in selected & self.neighbours(v):
                 res.add_edge(u, v)
+
         return res
 
     def normalize(self):

--- a/lib/graph/graph.py
+++ b/lib/graph/graph.py
@@ -326,7 +326,7 @@ class Graph(object):
         :param u: The vertex whose neighbors are to be returned
         :return: A frozenset of containing neighbors of the vertex
         """
-        return self.adj[u]
+        return frozenset(self.adj[u])
 
     def neighbours_set(self, centers):
         """


### PR DESCRIPTION
Implemented much more efficient subgraph function.

Changes:
lib/graph/graph.py
-subgraph vertex addition iterates over selected instead of self.nodes
-subgraph assumes all inputted vertices are in graph, those that aren’t
will be added as isolates
-subgraph edge addition sped up by utilizing set intersection
